### PR TITLE
snap: add required build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,3 +40,6 @@ parts:
     requirements: [requirements.txt]
     source: .
     stage-packages: [git]
+
+    # Required for cryptography
+    build-packages: [libssl-dev, libffi-dev]


### PR DESCRIPTION
Otherwise it fails to build on everything except amd64.