### PR TITLE
snap: add cargo to build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,4 +42,4 @@ parts:
     stage-packages: [git]
 
     # Required for cryptography
-    build-packages: [libssl-dev, libffi-dev]
+    build-packages: [libssl-dev, libffi-dev, cargo]


### PR DESCRIPTION
Another one required by cryptography.